### PR TITLE
Remove `$` so one can copy the snippet directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ heroku plugins:install @heroku-cli/plugin-free
 With the plugin installed, you can run it without any arguments to fetch all apps across personal and any Heroku Team you’re a part of.
 
 ```
-heroku apps:free
+$ heroku apps:free
 
 === Apps with Free Dynos & Data
  Name                           Team             Dyno Postgresql                     Redis

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The `apps:free` Heroku CLI plugin shows the apps using free dynos or free data (
 To get started, install the plugin from NPM.
 
 ```
-$ heroku plugins:install @heroku-cli/plugin-free
+heroku plugins:install @heroku-cli/plugin-free
 ```
 
 With the plugin installed, you can run it without any arguments to fetch all apps across personal and any Heroku Team you’re a part of.
 
 ```
-$ heroku apps:free
+heroku apps:free
 
 === Apps with Free Dynos & Data
  Name                           Team             Dyno Postgresql                     Redis


### PR DESCRIPTION
With the `$` it is not possible to just copy the install code and paste it.